### PR TITLE
Support advanced networking public ip if a mapping is done manually.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Provide, at a minimum, the required driver options in your `.kitchen.yml` file:
     OPTIONAL
       cloudstack_sync_time: [NUMBER OF SECONDS TO WAIT FOR CLOUD-SET-GUEST-PASSWORD/SSHKEY]
       keypair_search_directory: [PATH TO DIRECTORY (other than ~, ., and ~/.ssh) WITH KEYPAIR PEM FILE]
+      cloudstack_vm_public_ip: [PUBLIC_IP] # In case you use advanced networking and do static NAT manually.
 
 Then to specify different OS templates,
 

--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -125,7 +125,7 @@ module Kitchen
           end
 
           # debug("Keypair is #{keypair}")
-          state[:hostname] = server_info.fetch('nic').first.fetch('ipaddress')
+          state[:hostname] = config[:cloudstack_vm_public_ip] || server_info.fetch('nic').first.fetch('ipaddress')
           tcp_test_ssh(state[:hostname])
           debug("SSH Connectivity Validated.")
 


### PR DESCRIPTION
Hi there, I believe we could start supporting advanced networking. In the case the kitchen generated machines IPs are not publicly available, we need to support a way to handle the static NAT done between the public IP and the machines. This is a simple way to handle that. I believe we could do even better by handling the NAT via the API too but that's another layer of code I don't have yet. 
