### PR TITLE
Fail when server does not start

### DIFF
--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -114,6 +114,7 @@ module Kitchen
         if server_start['queryasyncjobresultresponse'].fetch('jobstatus').to_i == 2
           errortext = server_start['queryasyncjobresultresponse'].fetch('jobresult').fetch('errortext')
           error("ERROR! Job failed with #{errortext}")
+          raise ActionFailed, "Could not create server #{errortext}"
         end
 
         # jobstatus of 1 is a succesfully completed async job


### PR DESCRIPTION
When VM fails to start, the create function will pass through, and test kitchen will use localhost as the machine as the hostname is not set in state. This patch throws an exception when VM fails to start instead.
