### PR TITLE
Moved the wait_for_sshd inside the keypair/password/fixed password logic

### DIFF
--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -144,9 +144,6 @@ module Kitchen
           # binding.pry
           # debug("Keypair is #{keypair}")
           state[:hostname] = config[:cloudstack_vm_public_ip] || server_info.fetch('nic').first.fetch('ipaddress')
-          wait_for_sshd(state[:hostname])
-          
-          debug("SSH Connectivity Validated.")
 
           if (!keypair.nil?)
             debug("Using keypair: #{keypair}")
@@ -155,16 +152,28 @@ module Kitchen
             if ssh_key.split[0] == "ssh-rsa" or ssh_key.split[0] == "ssh-dsa"
               error("SSH key #{keypair} is not a Private Key. Please modify your .kitchen.yml")
             end
+
+            wait_for_sshd(state[:hostname], config[:username], {:keys => keypair})
+            debug("SSH connectivity validated with keypair.")
+
             ssh = Fog::SSH.new(state[:hostname], config[:username], {:keys => keypair})
             debug("Connecting to : #{state[:hostname]} as #{config[:username]} using keypair #{keypair}.")
           elsif (server_info.fetch('passwordenabled') == true)
             password = server_info.fetch('password')
             # Print out IP and password so you can record it if you want.
             info("Password for #{config[:username]} at #{state[:hostname]} is #{password}")
+
+            wait_for_sshd(state[:hostname], config[:username], {:password => password})
+            debug("SSH connectivity validated with cloudstack-set password.")
+
             ssh = Fog::SSH.new(state[:hostname], config[:username], {:password => password})
             debug("Connecting to : #{state[:hostname]} as #{config[:username]} using password #{password}.")
           elsif (!config[:password].nil?)
             info("Connecting with user #{config[:username]} with password #{config[:password]}")
+
+            wait_for_sshd(state[:hostname], config[:username], {:password => config[:password]})
+            debug("SSH connectivity validated with fixed password.")
+
             ssh = Fog::SSH.new(state[:hostname], config[:username], {:password => config[:password]})
           else
             info("No keypair specified (or file not found) nor is this a password enabled template. You will have to manually copy your SSH public key to #{state[:hostname]} to use this Kitchen.")

--- a/lib/kitchen/driver/cloudstack_version.rb
+++ b/lib/kitchen/driver/cloudstack_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Cloudstack Kitchen driver
-    CLOUDSTACK_VERSION = "0.20.0"
+    CLOUDSTACK_VERSION = "0.20.1"
   end
 end


### PR DESCRIPTION
The wait_for_sshd should honour the chosen authentication method, and only
try that specific method.

PS: This fix isn't perfect yet, as it still prompts for a password when the
provided password isn't accepted (can happen if SSH is already up, but
the server hasnt updated the users password through the cloud-utils yet).
I have a solution for that too, but it depends on changes in the test-kitchen.