### PR TITLE
Removes the default 45s sleep

### DIFF
--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -218,7 +218,7 @@ module Kitchen
           sleep 15
           false
         ensure
-          sync_time = 45
+          sync_time = 0
           if (config[:cloudstack_sync_time])
             sync_time = config[:cloudstack_sync_time]
           end


### PR DESCRIPTION
this can be removed, as the "wait_for_sshd" did become more intelligent, and
will block until it can establish a connection.