### PR TITLE
Stores the template-provided password in the main config.

### DIFF
--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -159,6 +159,7 @@ module Kitchen
             debug("Connecting to : #{state[:hostname]} as #{config[:username]} using keypair #{keypair}.")
           elsif (server_info.fetch('passwordenabled') == true)
             password = server_info.fetch('password')
+            config[:password] = password
             # Print out IP and password so you can record it if you want.
             info("Password for #{config[:username]} at #{state[:hostname]} is #{password}")
             ssh = Fog::SSH.new(state[:hostname], config[:username], {:password => password})


### PR DESCRIPTION
This is needed, as kitchen will reuse this to establish connections later on.

Might fix https://github.com/test-kitchen/kitchen-cloudstack/issues/11