### PR TITLE
Hostname setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ behavior can be overridden with additional options (e.g., to specify a SSH priva
     public_key_path: [PATH TO YOUR SSH PUBLIC KEY]
     username: [SSH USER]
     port: [SSH PORT]
+    host_name: [A UNIQUE HOST NAME] (Useful if facing ENAMETOOLONG exceptions in the chef run caused by long generated hostnames)
 
 Only disable SSL cert validation if you absolutely know what you are doing,
 but are stuck with an CloudStack deployment without valid SSL certs.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,11 @@ behavior can be overridden with additional options (e.g., to specify a SSH priva
     public_key_path: [PATH TO YOUR SSH PUBLIC KEY]
     username: [SSH USER]
     port: [SSH PORT]
-    host_name: [A UNIQUE HOST NAME] (Useful if facing ENAMETOOLONG exceptions in the chef run caused by long generated hostnames)
+
+host_name setting is  useful if you are facing ENAMETOOLONG exceptions in the 
+chef run caused by long generated hostnames)
+
+    host_name: [A UNIQUE HOST NAME]
 
 Only disable SSL cert validation if you absolutely know what you are doing,
 but are stuck with an CloudStack deployment without valid SSL certs.

--- a/Rakefile
+++ b/Rakefile
@@ -1,21 +1,21 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 require 'cane/rake_task'
 require 'tailor/rake_task'
 
-desc "Run cane to check quality metrics"
+desc 'Run cane to check quality metrics'
 Cane::RakeTask.new do |cane|
   cane.canefile = './.cane'
 end
 
 Tailor::RakeTask.new
 
-desc "Display LOC stats"
+desc 'Display LOC stats'
 task :stats do
   puts "\n## Production Code Stats"
-  sh "countloc -r lib"
+  sh 'countloc -r lib'
 end
 
-desc "Run all quality tasks"
+desc 'Run all quality tasks'
 task :quality => [:cane, :tailor, :stats]
 
 task :default => [:quality]

--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -50,23 +50,15 @@ module Kitchen
         options = {}
 
         config[:server_name] ||= generate_name(instance.name)
+
         options['displayname'] = config[:server_name]
+        options['networkids']  = config[:cloudstack_network_id]
+        options['securitygroupids'] = config[:cloudstack_security_group_id]
+        options['keypair'] = config[:cloudstack_ssh_keypair_name]
+        options['diskofferingid'] = config[:cloudstack_diskoffering_id]
+        options['name'] = config[:host_name]
 
-        if config[:cloudstack_network_id]
-          options['networkids'] = config[:cloudstack_network_id]
-        end
-
-        if config[:cloudstack_security_group_id]
-          options['securitygroupids'] = config[:cloudstack_security_group_id]
-        end
-
-        if config[:cloudstack_ssh_keypair_name]
-          options['keypair'] = config[:cloudstack_ssh_keypair_name]
-        end
-
-        if config[:cloudstack_diskoffering_id]
-          options['diskofferingid'] = config[:cloudstack_diskoffering_id]
-        end
+        options = sanitize(options)
 
         options[:templateid] = config[:cloudstack_template_id]
         options[:serviceofferingid] = config[:cloudstack_serviceoffering_id]
@@ -281,6 +273,12 @@ module Kitchen
           end
         end
         pieces.join sep
+      end
+
+      private
+
+      def sanitize(options)
+        options.reject { |k, v| v.nil? }
       end
     end
   end

--- a/lib/kitchen/driver/cloudstack_version.rb
+++ b/lib/kitchen/driver/cloudstack_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Cloudstack Kitchen driver
-    CLOUDSTACK_VERSION = "0.20.3"
+    CLOUDSTACK_VERSION = "0.20.4"
   end
 end


### PR DESCRIPTION
Chef does not play well with long hostname since it generates some temp files based on it and it causes an exception ENAMETOOLONG, allowing for setting the hostname is useful in the case your cloudstack implementation is generating long hostnames.