### PR TITLE
Makes it possible to expunge instances when destroying.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Provide, at a minimum, the required driver options in your `.kitchen.yml` file:
       cloudstack_api_url: [YOUR CLOUDSTACK API URL]
       require_chef_omnibus: latest (if you'll be using Chef)
     OPTIONAL
+      cloudstack_expunge: [TRUE/FALSE] # Whether or not you want the instance to be expunged, default false.
       cloudstack_sync_time: [NUMBER OF SECONDS TO WAIT FOR CLOUD-SET-GUEST-PASSWORD/SSHKEY]
       keypair_search_directory: [PATH TO DIRECTORY (other than ~, ., and ~/.ssh) WITH KEYPAIR PEM FILE]
       cloudstack_vm_public_ip: [PUBLIC_IP] # In case you use advanced networking and do static NAT manually.

--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -190,8 +190,19 @@ module Kitchen
         return unless state[:server_id]
         debug("Destroying #{state[:server_id]}")
         server = compute.servers.get(state[:server_id])
+        expunge =
+          if !!config[:cloudstack_expunge] == config[:cloudstack_expunge]
+            config[:cloudstack_expunge]
+          else
+            false
+          end
         if server
-          compute.destroy_virtual_machine({'id' => state[:server_id]})
+          compute.destroy_virtual_machine(
+            {
+              'id' => state[:server_id],
+              'expunge' => expunge
+            }
+          )
         end
         info("CloudStack instance <#{state[:server_id]}> destroyed.")
         state.delete(:server_id)

--- a/lib/kitchen/driver/cloudstack_version.rb
+++ b/lib/kitchen/driver/cloudstack_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Cloudstack Kitchen driver
-    CLOUDSTACK_VERSION = "0.20.4"
+    CLOUDSTACK_VERSION = "0.21.0"
   end
 end


### PR DESCRIPTION
If you use kitchen-cloudstack in a highly volatile environment, you probably want to expunge when destroying. This facilitates that.