### PR TITLE
Projectid and userdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Provide, at a minimum, the required driver options in your `.kitchen.yml` file:
       keypair_search_directory: [PATH TO DIRECTORY (other than ~, ., and ~/.ssh) WITH KEYPAIR PEM FILE]
       cloudstack_project_id: [PROJECT_ID] # To deploy VMs into project.
       cloudstack_vm_public_ip: [PUBLIC_IP] # In case you use advanced networking and do static NAT manually.
+      cloudstack_userdata: "#cloud-config\npackages:\n - htop\n" # double quote required.
 
 Then to specify different OS templates,
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Provide, at a minimum, the required driver options in your `.kitchen.yml` file:
       cloudstack_expunge: [TRUE/FALSE] # Whether or not you want the instance to be expunged, default false.
       cloudstack_sync_time: [NUMBER OF SECONDS TO WAIT FOR CLOUD-SET-GUEST-PASSWORD/SSHKEY]
       keypair_search_directory: [PATH TO DIRECTORY (other than ~, ., and ~/.ssh) WITH KEYPAIR PEM FILE]
+      cloudstack_project_id: [PROJECT_ID] # To deploy VMs into project.
       cloudstack_vm_public_ip: [PUBLIC_IP] # In case you use advanced networking and do static NAT manually.
 
 Then to specify different OS templates,

--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -42,6 +42,7 @@ module Kitchen
           :cloudstack_host => cloudstack_uri.host,
           :cloudstack_port => cloudstack_uri.port,
           :cloudstack_path => cloudstack_uri.path,
+          :cloudstack_project_id => config[:cloudstack_project_id],
           :cloudstack_scheme => cloudstack_uri.scheme
         )
       end

--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -21,6 +21,7 @@ require 'kitchen'
 require 'fog'
 require 'socket'
 require 'openssl'
+require 'base64'
 
 module Kitchen
   module Driver
@@ -61,6 +62,7 @@ module Kitchen
 
         options = sanitize(options)
 
+        options[:userdata] = convert_userdata(config[:cloudstack_userdata])
         options[:templateid] = config[:cloudstack_template_id]
         options[:serviceofferingid] = config[:cloudstack_serviceoffering_id]
         options[:zoneid] = config[:cloudstack_zone_id]
@@ -291,6 +293,14 @@ module Kitchen
 
       def sanitize(options)
         options.reject { |k, v| v.nil? }
+      end
+
+      def convert_userdata(user_data)
+        if user_data.match /^(?:[A-Za-z0-9+\/]{4}\n?)*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?$/
+          user_data
+        else
+          Base64.encode64(user_data)
+        end
       end
     end
   end

--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -59,10 +59,10 @@ module Kitchen
         options['keypair'] = config[:cloudstack_ssh_keypair_name]
         options['diskofferingid'] = config[:cloudstack_diskoffering_id]
         options['name'] = config[:host_name]
+        options[:userdata] = convert_userdata(config[:cloudstack_userdata]) if config[:cloudstack_userdata]
 
         options = sanitize(options)
 
-        options[:userdata] = convert_userdata(config[:cloudstack_userdata])
         options[:templateid] = config[:cloudstack_template_id]
         options[:serviceofferingid] = config[:cloudstack_serviceoffering_id]
         options[:zoneid] = config[:cloudstack_zone_id]


### PR DESCRIPTION
Add support to ``projectid`` and ``userdata``. 

``projectid`` can be defined to deploy testing VMs into a CloudStack project via:
``` 
driver_config:
  cloudstack_project_id:
```

``user-data`` can be define as a string, base64 encoded or not to enhance testing of template using cloud-init via: ``cloudstack_userdata``

README updated for those new params.

Tested with and without these new params, haven't got any issue so far using:
* CloudStack 4.7.x.
* test-kitchen 1.7.3
* fog 1.38.0

