### PR TITLE
Make sure Etc.getlogin is not nil before reading its length

### DIFF
--- a/lib/kitchen/driver/cloudstack.rb
+++ b/lib/kitchen/driver/cloudstack.rb
@@ -289,11 +289,11 @@ module Kitchen
           Array.new(8) { rand(36).to_s(36) }.join
         ]
         until pieces.join(sep).length <= 64 do
-          if pieces[2].length > 24
+          if pieces[2] && pieces[2].length > 24
             pieces[2] = pieces[2][0..-2]
-          elsif pieces[1].length > 16
+          elsif pieces[1] && pieces[1].length > 16
             pieces[1] = pieces[1][0..-2]
-          elsif pieces[0].length > 16
+          elsif pieces[0] && pieces[0].length > 16
             pieces[0] = pieces[0][0..-2]
           end
         end


### PR DESCRIPTION
I've noticed this issue that `Etc.getlogin` is `nil` while:

- long instance name (30 characters)
- event longer hostname (~80 characters)
- host was a docker container (not sure if it's relevant)

causes `generate_name` to throw an error:

```
$ kitchen test chef-latest -l debug
-----> Starting Kitchen (v1.23.2)
D      Berksfile found at /builds/cookbooks/cookbook_name/Berksfile, loading Berkshelf
D      Berkshelf 7.0.6 library loaded
D      Berksfile found at /builds/cookbooks/cookbook_name/Berksfile, loading Berkshelf
D      Berkshelf 7.0.6 previously loaded
-----> Cleaning up any prior instances of <default-ubuntu1604-chef-latest>
-----> Destroying <default-ubuntu1604-chef-latest>...
       Finished destroying <default-ubuntu1604-chef-latest> (0m0.00s).
-----> Testing <default-ubuntu1604-chef-latest>
-----> Creating <default-ubuntu1604-chef-latest>...
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ActionFailed
>>>>>> Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [undefined method `length' for nil:NilClass] on default-ubuntu1604-chef-latest
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
>>>>>> Also try running `kitchen diagnose --all` for configuration
D      ------Exception-------
D      Class: Kitchen::ActionFailed
D      Message: 1 actions failed.
>>>>>>     Failed to complete #create action: [undefined method `length' for nil:NilClass] on default-ubuntu1604-chef-latest
D      ----------------------
D      ------Backtrace-------
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/command.rb:183:in `report_errors'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/command.rb:174:in `run_action'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/command/test.rb:42:in `block in call'
D      /opt/chefdk/embedded/lib/ruby/2.5.0/benchmark.rb:293:in `measure'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/command/test.rb:38:in `call'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/cli.rb:52:in `perform'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/cli.rb:245:in `test'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/thor-0.20.0/lib/thor/base.rb:466:in `start'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/bin/kitchen:13:in `block in <top (required)>'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/errors.rb:171:in `with_friendly_errors'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/bin/kitchen:13:in `<top (required)>'
D      /opt/chefdk/bin/kitchen:293:in `load'
D      /opt/chefdk/bin/kitchen:293:in `<main>'
D      ----End Backtrace-----
D      -Composite Exception--
D      Class: Kitchen::ActionFailed
D      Message: Failed to complete #create action: [undefined method `length' for nil:NilClass] on default-ubuntu1604-chef-latest
D      ----------------------
D      ------Backtrace-------
D      /root/.chefdk/gem/ruby/2.5.0/gems/kitchen-cloudstack-0.23.0/lib/kitchen/driver/cloudstack.rb:294:in `generate_name'
D      /root/.chefdk/gem/ruby/2.5.0/gems/kitchen-cloudstack-0.23.0/lib/kitchen/driver/cloudstack.rb:54:in `create_server'
D      /root/.chefdk/gem/ruby/2.5.0/gems/kitchen-cloudstack-0.23.0/lib/kitchen/driver/cloudstack.rb:85:in `create'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:484:in `public_send'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:484:in `block in perform_action'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:551:in `synchronize_or_call'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:513:in `block in action'
D      /opt/chefdk/embedded/lib/ruby/2.5.0/benchmark.rb:293:in `measure'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:512:in `action'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:484:in `perform_action'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:394:in `create_action'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:382:in `block (2 levels) in transition_to'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/lifecycle_hooks.rb:45:in `run_with_hooks'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:381:in `block in transition_to'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:380:in `each'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:380:in `transition_to'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:162:in `verify'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:191:in `block in test'
D      /opt/chefdk/embedded/lib/ruby/2.5.0/benchmark.rb:293:in `measure'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:187:in `test'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/command.rb:197:in `public_send'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/command.rb:197:in `run_action_in_thread'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/command.rb:169:in `block (2 levels) in run_action'
D      ----End Backtrace-----
D      ---Nested Exception---
D      Class: Kitchen::ActionFailed
D      Message: Failed to complete #create action: [undefined method `length' for nil:NilClass]
D      ----------------------
D      ------Backtrace-------
D      /root/.chefdk/gem/ruby/2.5.0/gems/kitchen-cloudstack-0.23.0/lib/kitchen/driver/cloudstack.rb:294:in `generate_name'
D      /root/.chefdk/gem/ruby/2.5.0/gems/kitchen-cloudstack-0.23.0/lib/kitchen/driver/cloudstack.rb:54:in `create_server'
D      /root/.chefdk/gem/ruby/2.5.0/gems/kitchen-cloudstack-0.23.0/lib/kitchen/driver/cloudstack.rb:85:in `create'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:484:in `public_send'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:484:in `block in perform_action'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:551:in `synchronize_or_call'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:513:in `block in action'
D      /opt/chefdk/embedded/lib/ruby/2.5.0/benchmark.rb:293:in `measure'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:512:in `action'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:484:in `perform_action'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:394:in `create_action'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:382:in `block (2 levels) in transition_to'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/lifecycle_hooks.rb:45:in `run_with_hooks'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:381:in `block in transition_to'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:380:in `each'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:380:in `transition_to'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:162:in `verify'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:191:in `block in test'
D      /opt/chefdk/embedded/lib/ruby/2.5.0/benchmark.rb:293:in `measure'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/instance.rb:187:in `test'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/command.rb:197:in `public_send'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/command.rb:197:in `run_action_in_thread'
D      /opt/chefdk/embedded/lib/ruby/gems/2.5.0/gems/test-kitchen-1.23.2/lib/kitchen/command.rb:169:in `block (2 levels) in run_action'
D      ----End Backtrace-----
```