### PR TITLE
Add option to automatically create SSH firewall rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Provide, at a minimum, the required driver options in your `.kitchen.yml` file:
       cloudstack_project_id: [PROJECT_ID] # To deploy VMs into project.
       cloudstack_vm_public_ip: [PUBLIC_IP] # In case you use advanced networking and do static NAT manually.
       associate_public_ip: [TRUE/FALSE] # If you want kitchen to automatically associate a public IP, default false.
+      cloudstack_create_firewall_rule: [TRUE/FALSE] # If you want Kitchen to automatically create firewall rule for public IP to reach SSH (port 22)
       cloudstack_userdata: "#cloud-config\npackages:\n - htop\n" # double quote required.
 
 Then to specify different OS templates,

--- a/lib/kitchen/driver/cloudstack_version.rb
+++ b/lib/kitchen/driver/cloudstack_version.rb
@@ -21,6 +21,6 @@ module Kitchen
   module Driver
 
     # Version string for Cloudstack Kitchen driver
-    CLOUDSTACK_VERSION = "0.23.1"
+    CLOUDSTACK_VERSION = "0.23.2"
   end
 end


### PR DESCRIPTION
When you using L3 networking in CloudStack sometimes in addition to public IP and port forward you have to create firewall rule for it.