### PR TITLE
Loosen the Test Kitchen + dev deps

### DIFF
--- a/kitchen-cloudstack.gemspec
+++ b/kitchen-cloudstack.gemspec
@@ -11,21 +11,20 @@ Gem::Specification.new do |spec|
   spec.description   = %q{A Test Kitchen Driver for Apache CloudStack}
   spec.summary       = %q{Provides an interface for Test Kitchen to be able to run jobs against an Apache CloudStack cloud.}
   spec.homepage      = 'https://github.com/test-kitchen/kitchen-cloudstack'
-  spec.license       = 'Apache 2.0'
+  spec.license       = 'Apache-2.0'
 
   spec.files         = `git ls-files`.split($/)
-  spec.executables   = []
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'test-kitchen', '~> 1.0', '>= 1.0.0'
-  spec.add_dependency 'fog', '~> 1.23', '>= 1.23.0'
+  spec.add_dependency 'test-kitchen', '>= 1.0.0', "< 3"
+  spec.add_dependency 'fog', '~> 1.23'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
-  spec.add_development_dependency 'rake', '~> 0'
+  spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'rake'
 
   spec.add_development_dependency 'cane', '~> 2'
   spec.add_development_dependency 'tailor', '~> 1'
-  spec.add_development_dependency 'countloc', '~> 0'
-  spec.add_development_dependency 'pry', '~> 0'
+  spec.add_development_dependency 'countloc'
+  spec.add_development_dependency 'pry'
 end


### PR DESCRIPTION
Test Kitchen 2.0 will have no impact on this plugin.
I also loosened up the dev deps a bit to prevent conflicts with other
gems

Signed-off-by: Tim Smith <tsmith@chef.io>